### PR TITLE
Postgresql as the main database adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,22 +1,20 @@
+# frozen_string_literal: true
+#
 source 'https://rubygems.org'
+ruby '2.4.0'
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
   "https://github.com/#{repo_name}.git"
 end
 
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.0.2'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
-
-gem 'devise'
+# Use postgres as the database for Active Record
+gem 'pg'
 
 # Use Puma as the app server
 gem 'puma', '~> 3.0'
-
-gem 'twitter-bootstrap-rails'
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
@@ -25,13 +23,14 @@ gem 'jquery-rails'
 gem 'jbuilder', '~> 2.5'
 
 gem 'turbolinks'
-
-gem 'capybara'
-gem 'ffaker'
-gem 'factory_girl'
+gem 'devise'
+gem 'twitter-bootstrap-rails'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem 'capybara'
+  gem 'ffaker'
+  gem 'factory_girl'
   gem 'byebug', platform: :mri
   gem 'rspec-rails', '~> 3.5'
 end
@@ -40,7 +39,6 @@ group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '~> 3.0.5'
-  gem 'rspec-rails', '~> 3.5'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
     nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     orm_adapter (0.5.0)
+    pg (0.20.0)
     public_suffix (2.0.5)
     puma (3.8.2)
     rack (2.0.1)
@@ -165,7 +166,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
@@ -204,16 +204,19 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
+  pg
   puma (~> 3.0)
   rails (~> 5.0.2)
   rspec-rails (~> 3.5)
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
   turbolinks
   twitter-bootstrap-rails
   tzinfo-data
   web-console (>= 3.3.0)
+
+RUBY VERSION
+   ruby 2.4.0p0
 
 BUNDLED WITH
    1.14.6

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,18 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
-  pool: 5
-  timeout: 5000
+  adapter: postgresql
+  encode: unicode
+  pool: <%= ENV.fetch('RAILS_MAX_THREADS') { 5 } %>
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: miniapp_autoseg_development
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: miniapp_autoseg_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: miniapp_autoseg_production
+  username: miniapp_autoseg
+  password: <%= ENV['GAME_EVALUATION_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
In this PR i've changed `Gemfile` and `database.yml` to use postgresql as the main database adapter for ActiveRecord. This is necessary to deploy the application on Heroku.

@aramsm 